### PR TITLE
x86_64: added toolchain config

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,19 +12,19 @@
 # *******************************************************************************
 module(
     name = "score_toolchains_rust",
-    version = "0.1",
+    version = "0.1.1",
     compatibility_level = 0,
 )
 
 bazel_dep(name = "rules_rust", version = "0.56.0")
 bazel_dep(name = "platforms", version = "0.0.11")
 
-bazel_dep(name = "rust_qnx8_toolchain", version = "1.0.0")
+bazel_dep(name = "rust_qnx8_toolchain", version = "1.2.0")
 archive_override(
     module_name = "rust_qnx8_toolchain",
     urls = [
-        "https://github.com/qorix-group/rust-lang-qnx8/releases/download/1.0.0/qnx8_rust_toolchain.tar.gz",
+        "https://github.com/qorix-group/rust-lang-qnx8/releases/download/1.2.0/qnx8_rust_toolchain.tar.gz",
     ],
     strip_prefix = "qnx8",
-    integrity = "sha256-225b5fbbf53ebbf8c2d3ee676c0359d96342317f17a8aee519ac0db3f41cb27e",
+    integrity = "sha256-eQOopREOYCL5vtTb6c1cwZrql4GVrJ1FqgxarQRe1xs=",
 )

--- a/toolchains/x86_64-unknown-linux-gnu/BUILD.bazel
+++ b/toolchains/x86_64-unknown-linux-gnu/BUILD.bazel
@@ -1,0 +1,40 @@
+load("@rules_rust//rust:toolchain.bzl", "rust_toolchain")
+
+# Host Linux x86_64 toolchain (proc-macros & build scripts run with this)
+rust_toolchain(
+    name = "rust_toolchain_x86_64_linux",
+
+    # use the SAME binaries as your QNX toolchain archive (same rustc build)
+    rustc         = "@rust_qnx8_toolchain//:rustc",
+    cargo         = "@rust_qnx8_toolchain//:cargo",
+    rust_doc      = "@rust_qnx8_toolchain//:rustdoc",
+    clippy_driver = "@rust_qnx8_toolchain//:clippy_driver",
+    rustc_lib     = "@rust_qnx8_toolchain//:rustc_lib",
+
+    # host std (most Rust toolchain bundles have this; if yours exposes it, wire it)
+    # You can omit rust_std here if the host std is embedded; otherwise add:
+    rust_std      = "@rust_qnx8_toolchain//:rust_std-x86_64-unknown-linux-gnu",
+
+    target_triple = "x86_64-unknown-linux-gnu",
+    exec_triple   = "x86_64-unknown-linux-gnu",
+
+    staticlib_ext = ".a",
+    dylib_ext     = ".so",
+    binary_ext    = "",
+    default_edition = "2021",
+    stdlib_linkflags = [],
+)
+
+toolchain(
+    name = "toolchain_x86_64_linux",
+    toolchain_type = "@rules_rust//rust:toolchain_type",
+    toolchain = ":rust_toolchain_x86_64_linux",
+    exec_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+    target_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+)


### PR DESCRIPTION
We introduced a custom toolchain configuration for the x86_64-unknown-linux-gnu host to align the host toolchain with the same rustc version used for the QNX 8.0 target.

Without this, Bazel used the system/default host toolchain, leading to mismatched proc_macro versions and inconsistent standard libraries between host and target builds. This caused build failures in mixed Rust/Cargo targets that rely on shared procedural macros and host tools.

The custom config ensures:
- A reproducible rustc + stdlib pair for the host
- Consistent versioning across host (x86_64) and QNX (aarch64) toolchains
- Proper integration with rules_rust and score_toolchains_rust platform definitions

Fixes: eclipse-score/score#1916