### PR TITLE
coverage: added support for coverage tools too

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,7 @@
 # *******************************************************************************
 module(
     name = "score_toolchains_rust",
-    version = "0.3.0",
+    version = "0.4.0",
     compatibility_level = 0,
 )
 
@@ -31,6 +31,9 @@ ferrocene.toolchain(
     name = "ferrocene_x86_64_unknown_linux_gnu",
     url = "https://github.com/eclipse-score/ferrocene_toolchain_builder/releases/download/1.0.1/ferrocene-779fbed05ae9e9fe2a04137929d99cc9b3d516fd-x86_64-unknown-linux-gnu.tar.gz",
     sha256 = "4c08b41eaafd39cff66333ca4d4646a5331c780050b8b9a8447353fcd301dddc",
+    coverage_tools_url = "https://github.com/eclipse-score/ferrocene_toolchain_builder/releases/download/1.0.1/coverage-tools-779fbed05ae9e9fe2a04137929d99cc9b3d516fd-x86_64-unknown-linux-gnu.tar.gz",
+    coverage_tools_sha256 = "497958e925bc94833ea226d68f6d5ba38bd890f571c73e230141d2923e30dd94",
+    coverage_tools_strip_prefix = "779fbed05ae9e9fe2a04137929d99cc9b3d516fd/x86_64-unknown-linux-gnu",
     target_triple = "x86_64-unknown-linux-gnu",
     exec_triple = "x86_64-unknown-linux-gnu",
     extra_rustc_flags = [
@@ -49,6 +52,9 @@ ferrocene.toolchain(
     name = "ferrocene_x86_64_pc_nto_qnx800",
     url = "https://github.com/eclipse-score/ferrocene_toolchain_builder/releases/download/1.0.1/ferrocene-779fbed05ae9e9fe2a04137929d99cc9b3d516fd-x86_64-pc-nto-qnx800.tar.gz",
     sha256 = "6daabbe20c0b06551335f83c2490326ce447759628dea04cd1c90d297c3a0bd3",
+    coverage_tools_url = "https://github.com/eclipse-score/ferrocene_toolchain_builder/releases/download/1.0.1/coverage-tools-779fbed05ae9e9fe2a04137929d99cc9b3d516fd-x86_64-unknown-linux-gnu.tar.gz",
+    coverage_tools_sha256 = "497958e925bc94833ea226d68f6d5ba38bd890f571c73e230141d2923e30dd94",
+    coverage_tools_strip_prefix = "779fbed05ae9e9fe2a04137929d99cc9b3d516fd/x86_64-unknown-linux-gnu",
     target_triple = "x86_64-pc-nto-qnx800",
     exec_triple = "x86_64-unknown-linux-gnu",
     extra_rustc_flags = [
@@ -67,6 +73,9 @@ ferrocene.toolchain(
     name = "ferrocene_aarch64_unknown_nto_qnx800",
     url = "https://github.com/eclipse-score/ferrocene_toolchain_builder/releases/download/1.0.1/ferrocene-779fbed05ae9e9fe2a04137929d99cc9b3d516fd-aarch64-unknown-nto-qnx800.tar.gz",
     sha256 = "563a2438324ee1c6fdcfd13fbe352bedf1cf3f0756d07bb7ba7bdca334df92bf",
+    coverage_tools_url = "https://github.com/eclipse-score/ferrocene_toolchain_builder/releases/download/1.0.1/coverage-tools-779fbed05ae9e9fe2a04137929d99cc9b3d516fd-x86_64-unknown-linux-gnu.tar.gz",
+    coverage_tools_sha256 = "497958e925bc94833ea226d68f6d5ba38bd890f571c73e230141d2923e30dd94",
+    coverage_tools_strip_prefix = "779fbed05ae9e9fe2a04137929d99cc9b3d516fd/x86_64-unknown-linux-gnu",
     target_triple = "aarch64-unknown-nto-qnx800",
     exec_triple = "x86_64-unknown-linux-gnu",
     extra_rustc_flags = [

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ extension to wrap custom Ferrocene archives.
 
 - `MODULE.bazel`: pins Ferrocene 1.0.1 archives and depends on `score_bazel_platforms`.
 - `extensions/ferrocene_toolchain_ext.bzl`: bzlmod extension to wrap arbitrary Ferrocene archives.
+- Optional Ferrocene Rust coverage tools (`symbol-report`, `blanket`) when configured.
 - `toolchains/ferrocene/BUILD.bazel`: aliases to the preconfigured toolchains declared in `MODULE.bazel`.
 
 > Note: This module no longer ships platform definitions or the old rust sysroot
@@ -24,6 +25,13 @@ register_toolchains(
 )
 ```
 
+Coverage tools are available from the generated repositories (wrappers set `LD_LIBRARY_PATH` automatically):
+
+```
+bazel run @score_toolchains_rust//toolchains/ferrocene:ferrocene_x86_64_unknown_linux_gnu_symbol-report -- --help
+bazel run @score_toolchains_rust//toolchains/ferrocene:ferrocene_x86_64_unknown_linux_gnu_blanket -- --help
+```
+
 ## Wrapping your own Ferrocene archives
 
 ```python
@@ -39,6 +47,8 @@ ferrocene.toolchain(
     name = "ferrocene_x86_64_unknown_linux_gnu",
     url = "https://github.com/eclipse-score/ferrocene_toolchain_builder/releases/download/1.0.1/ferrocene-779fbed05ae9e9fe2a04137929d99cc9b3d516fd-x86_64-unknown-linux-gnu.tar.gz",
     sha256 = "4c08b41eaafd39cff66333ca4d4646a5331c780050b8b9a8447353fcd301dddc",
+    coverage_tools_url = "https://github.com/eclipse-score/ferrocene_toolchain_builder/releases/download/1.0.1/coverage-tools-779fbed05ae9e9fe2a04137929d99cc9b3d516fd-x86_64-unknown-linux-gnu.tar.gz",
+    coverage_tools_sha256 = "06298b2f809a99c4a649c24763add29243e33865e8561683dd8f52724c4b9e18",
     target_triple = "x86_64-unknown-linux-gnu",
     exec_triple = "x86_64-unknown-linux-gnu",
 )
@@ -65,6 +75,7 @@ Base URL:
 | `ferrocene-779fbed05ae9e9fe2a04137929d99cc9b3d516fd-x86_64-unknown-linux-gnu.tar.gz` | `4c08b41eaafd39cff66333ca4d4646a5331c780050b8b9a8447353fcd301dddc` |
 | `ferrocene-779fbed05ae9e9fe2a04137929d99cc9b3d516fd-x86_64-unknown-ferrocene.subset.tar.gz` | `e4dbaab02bfdf2f0f3b008ce14d7770c54bc3cea69fd3bb45778b4a3d36d0fa0` |
 | `ferrocene-779fbed05ae9e9fe2a04137929d99cc9b3d516fd-x86_64-pc-nto-qnx800.tar.gz` | `6daabbe20c0b06551335f83c2490326ce447759628dea04cd1c90d297c3a0bd3` |
+| `coverage-tools-779fbed05ae9e9fe2a04137929d99cc9b3d516fd-x86_64-unknown-linux-gnu.tar.gz` | `06298b2f809a99c4a649c24763add29243e33865e8561683dd8f52724c4b9e18` |
 
 ---
 

--- a/extensions/ferrocene_toolchain_ext.bzl
+++ b/extensions/ferrocene_toolchain_ext.bzl
@@ -17,13 +17,12 @@ This extension wraps a prebuilt Ferrocene archive (e.g. produced by
 - Filegroups for `rustc`, `cargo`, `rustdoc`, `clippy-driver`, and libs.
 - A `rust_toolchain` + `toolchain` definition for `rules_rust`.
 
-The produced repository is self-contained and can be registered via
-`register_toolchains("@<repo>//:<toolchain_name>_toolchain")`.
+Optionally, the same repository can include the Ferrocene Rust coverage tools
+(`symbol-report` and `blanket`) with wrapper scripts that set `LD_LIBRARY_PATH`
+for the embedded `rustc_private` shared libraries.
 """
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-_BUILD_TMPL = """\
+_BUILD_TMPL = """\\
 load("@rules_rust//rust:toolchain.bzl", "rust_stdlib_filegroup", "rust_toolchain")
 
 package(default_visibility = ["//visibility:public"])
@@ -128,13 +127,88 @@ toolchain(
     exec_compatible_with = {exec_compatible_with},
     target_compatible_with = {target_compatible_with},
 )
+
+{coverage_tools_block}
 """
+
+_COVERAGE_TOOLS_TMPL = """\\
+filegroup(
+    name = "symbol-report-bin",
+    srcs = ["symbol-report"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "blanket-bin",
+    srcs = ["blanket"],
+    visibility = ["//visibility:public"],
+)
+
+sh_binary(
+    name = "symbol-report-wrapper",
+    srcs = ["symbol-report.sh"],
+    data = [
+        ":symbol-report-bin",
+        ":rustc_lib",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+sh_binary(
+    name = "blanket-wrapper",
+    srcs = ["blanket.sh"],
+    data = [
+        ":blanket-bin",
+        ":rustc_lib",
+    ],
+    visibility = ["//visibility:public"],
+)
+"""
+
+_WRAPPER_SCRIPT_TMPL = """#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bin="${script_dir}/__TOOL__"
+
+if [[ ! -x "${bin}" ]]; then
+  echo "Missing __TOOL__ binary at ${bin}" >&2
+  exit 1
+fi
+
+target_triple="__TARGET_TRIPLE__"
+
+lib_dirs=(
+  "${script_dir}/lib"
+  "${script_dir}/lib/rustlib/${target_triple}/lib"
+  "${script_dir}/usr/lib"
+  "${script_dir}/usr/lib/rustlib/${target_triple}/lib"
+  "${script_dir}/usr/local/lib"
+  "${script_dir}/usr/local/lib/rustlib/${target_triple}/lib"
+)
+
+ld_paths=()
+for dir in "${lib_dirs[@]}"; do
+  if [[ -d "${dir}" ]]; then
+    ld_paths+=("${dir}")
+  fi
+done
+
+if [[ ${#ld_paths[@]} -gt 0 ]]; then
+  export LD_LIBRARY_PATH="$(IFS=:; echo "${ld_paths[*]}")${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+fi
+
+exec "${bin}" "$@"
+"""
+
+
 
 def _fmt_list(values):
     """Render a string list for embedding into Starlark text."""
     if not values:
         return "[]"
     return "[\n        " + ",\n        ".join(['"%s"' % v for v in values]) + "\n    ]"
+
 
 def _fmt_dict(values):
     """Render a string->string dict for embedding into Starlark text."""
@@ -147,7 +221,8 @@ def _fmt_dict(values):
         items.append('"%s": "%s"' % (key, values[key]))
     return "{\n        " + ",\n        ".join(items) + "\n    }"
 
-def _render_build_content(args):
+
+def _render_build_content(args, coverage_tools_block):
     return _BUILD_TMPL.format(
         toolchain_name = args.toolchain_name,
         target_triple = args.target_triple,
@@ -162,18 +237,103 @@ def _render_build_content(args):
         exec_compatible_with = _fmt_list(args.exec_compatible_with),
         target_compatible_with = _fmt_list(args.target_compatible_with),
         env = _fmt_dict(args.env),
+        coverage_tools_block = coverage_tools_block,
     )
+
+
+def _render_wrapper_script(tool, target_triple):
+    return _WRAPPER_SCRIPT_TMPL.replace("__TOOL__", tool).replace("__TARGET_TRIPLE__", target_triple)
+
+
+def _ferrocene_toolchain_repo_impl(ctx):
+    ctx.download_and_extract(
+        url = ctx.attr.url,
+        sha256 = ctx.attr.sha256,
+        strip_prefix = ctx.attr.strip_prefix,
+    )
+
+    coverage_tools_block = ""
+    if ctx.attr.coverage_tools_url:
+        if not ctx.attr.coverage_tools_sha256:
+            fail("coverage_tools_sha256 must be set when coverage_tools_url is provided")
+        ctx.download_and_extract(
+            url = ctx.attr.coverage_tools_url,
+            sha256 = ctx.attr.coverage_tools_sha256,
+            strip_prefix = ctx.attr.coverage_tools_strip_prefix,
+        )
+        ctx.file(
+            "symbol-report.sh",
+            _render_wrapper_script("symbol-report", ctx.attr.target_triple),
+            executable = True,
+        )
+        ctx.file(
+            "blanket.sh",
+            _render_wrapper_script("blanket", ctx.attr.target_triple),
+            executable = True,
+        )
+        coverage_tools_block = _COVERAGE_TOOLS_TMPL
+
+    ctx.file("BUILD.bazel", _render_build_content(ctx.attr, coverage_tools_block))
+
+
+ferrocene_toolchain_repo = repository_rule(
+    implementation = _ferrocene_toolchain_repo_impl,
+    attrs = {
+        "url": attr.string(mandatory = True),
+        "sha256": attr.string(mandatory = True),
+        "strip_prefix": attr.string(default = ""),
+        "toolchain_name": attr.string(default = "rust_ferrocene"),
+        "target_triple": attr.string(mandatory = True),
+        "exec_triple": attr.string(default = "x86_64-unknown-linux-gnu"),
+        "staticlib_ext": attr.string(default = ".a"),
+        "dylib_ext": attr.string(default = ".so"),
+        "binary_ext": attr.string(default = ""),
+        "default_edition": attr.string(default = "2021"),
+        "stdlib_linkflags": attr.string_list(default = []),
+        "extra_rustc_flags": attr.string_list(default = []),
+        "extra_exec_rustc_flags": attr.string_list(default = []),
+        "env": attr.string_dict(default = {}),
+        "exec_compatible_with": attr.string_list(default = [
+            "@platforms//cpu:x86_64",
+            "@platforms//os:linux",
+        ]),
+        "target_compatible_with": attr.string_list(default = [
+            "@platforms//cpu:x86_64",
+            "@platforms//os:linux",
+        ]),
+        "coverage_tools_url": attr.string(default = ""),
+        "coverage_tools_sha256": attr.string(default = ""),
+        "coverage_tools_strip_prefix": attr.string(default = ""),
+    },
+)
+
 
 def _ferrocene_toolchain_ext_impl(ctx):
     for mod in ctx.modules:
         for toolchain in mod.tags.toolchain:
-            http_archive(
+            ferrocene_toolchain_repo(
                 name = toolchain.name,
-                urls = [toolchain.url],
+                url = toolchain.url,
                 sha256 = toolchain.sha256,
                 strip_prefix = toolchain.strip_prefix,
-                build_file_content = _render_build_content(toolchain),
+                toolchain_name = toolchain.toolchain_name,
+                target_triple = toolchain.target_triple,
+                exec_triple = toolchain.exec_triple,
+                staticlib_ext = toolchain.staticlib_ext,
+                dylib_ext = toolchain.dylib_ext,
+                binary_ext = toolchain.binary_ext,
+                default_edition = toolchain.default_edition,
+                stdlib_linkflags = toolchain.stdlib_linkflags,
+                extra_rustc_flags = toolchain.extra_rustc_flags,
+                extra_exec_rustc_flags = toolchain.extra_exec_rustc_flags,
+                env = toolchain.env,
+                exec_compatible_with = toolchain.exec_compatible_with,
+                target_compatible_with = toolchain.target_compatible_with,
+                coverage_tools_url = toolchain.coverage_tools_url,
+                coverage_tools_sha256 = toolchain.coverage_tools_sha256,
+                coverage_tools_strip_prefix = toolchain.coverage_tools_strip_prefix,
             )
+
 
 ferrocene_toolchain_ext = module_extension(
     implementation = _ferrocene_toolchain_ext_impl,
@@ -232,6 +392,18 @@ ferrocene_toolchain_ext = module_extension(
                         "@platforms//os:linux",
                     ],
                     doc = "Compatibility constraints for the target platform.",
+                ),
+                "coverage_tools_url": attr.string(
+                    default = "",
+                    doc = "Optional URL of the Ferrocene Rust coverage tools archive.",
+                ),
+                "coverage_tools_sha256": attr.string(
+                    default = "",
+                    doc = "SHA256 of the coverage tools archive (hex).",
+                ),
+                "coverage_tools_strip_prefix": attr.string(
+                    default = "",
+                    doc = "Optional strip_prefix for the coverage tools archive.",
                 ),
             },
         ),

--- a/toolchains/ferrocene/BUILD.bazel
+++ b/toolchains/ferrocene/BUILD.bazel
@@ -22,11 +22,41 @@ alias(
 )
 
 alias(
+    name = "ferrocene_x86_64_unknown_linux_gnu_symbol-report",
+    actual = "@ferrocene_x86_64_unknown_linux_gnu//:symbol-report-wrapper",
+)
+
+alias(
+    name = "ferrocene_x86_64_unknown_linux_gnu_blanket",
+    actual = "@ferrocene_x86_64_unknown_linux_gnu//:blanket-wrapper",
+)
+
+alias(
     name = "ferrocene_x86_64_pc_nto_qnx800",
     actual = "@ferrocene_x86_64_pc_nto_qnx800//:rust_ferrocene_toolchain",
 )
 
 alias(
+    name = "ferrocene_x86_64_pc_nto_qnx800_symbol-report",
+    actual = "@ferrocene_x86_64_pc_nto_qnx800//:symbol-report-wrapper",
+)
+
+alias(
+    name = "ferrocene_x86_64_pc_nto_qnx800_blanket",
+    actual = "@ferrocene_x86_64_pc_nto_qnx800//:blanket-wrapper",
+)
+
+alias(
     name = "ferrocene_aarch64_unknown_nto_qnx800",
     actual = "@ferrocene_aarch64_unknown_nto_qnx800//:rust_ferrocene_toolchain",
+)
+
+alias(
+    name = "ferrocene_aarch64_unknown_nto_qnx800_symbol-report",
+    actual = "@ferrocene_aarch64_unknown_nto_qnx800//:symbol-report-wrapper",
+)
+
+alias(
+    name = "ferrocene_aarch64_unknown_nto_qnx800_blanket",
+    actual = "@ferrocene_aarch64_unknown_nto_qnx800//:blanket-wrapper",
 )


### PR DESCRIPTION
  What we did:

  1. Tell Bazel where to download them ( the ferrocence helper coverage tools)

  - We added the URL and SHA256 checksum of the tarball that contains the tools.
  - This makes Bazel fetch the tools automatically.

  2. Unpack and expose the binaries

  - The archive has a nested folder, so we added a “strip prefix” so Bazel finds the binaries inside it.
  - We created Bazel targets that point to those binaries.

  3. Provide wrappers

  - We generate wrapper scripts so the tools can be run correctly by Bazel.
  - Then we expose them as:
      - @score_toolchains_rust//toolchains/ferrocene:<triple>_symbol-report
      - @score_toolchains_rust//toolchains/ferrocene:<triple>_blanket

  Why this matters:
  score_tooling will rely on those targets.