### PR TITLE
Use libc++ for x86_64 toolchain

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -38,7 +38,7 @@ ferrocene.toolchain(
     exec_triple = "x86_64-unknown-linux-gnu",
     extra_rustc_flags = [
         "-Clink-arg=-Wl,--no-as-needed",
-        "-Clink-arg=-lstdc++",
+        "-Clink-arg=-lc++",
         "-Clink-arg=-lm",
         "-Clink-arg=-lc",
     ],


### PR DESCRIPTION
This enables the rust toolchain to compile with the llvm toolchain as backend.