### PR TITLE
Revert "Use libc++ for x86_64 toolchain"

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -38,7 +38,7 @@ ferrocene.toolchain(
     exec_triple = "x86_64-unknown-linux-gnu",
     extra_rustc_flags = [
         "-Clink-arg=-Wl,--no-as-needed",
-        "-Clink-arg=-lc++",
+        "-Clink-arg=-lstdc++",
         "-Clink-arg=-lm",
         "-Clink-arg=-lc",
     ],


### PR DESCRIPTION
Reverts eclipse-score/toolchains_rust#14 as this breaks all repos that are using feroceen and gcc (majority).