### PR TITLE
examples: add basic Rust example with CI smoke tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,10 @@
 common --registry=https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/
 common --registry=https://bcr.bazel.build
+
+# ------------------------------------------------------------------------------
+# Smoke-test config for the in-repo examples (see examples/ and
+# .github/workflows/examples.yml). Consumes the toolchains exactly the way
+# downstream repositories do, via --extra_toolchains.
+# ------------------------------------------------------------------------------
+build:smoke --extra_toolchains=//toolchains/ferrocene:ferrocene_x86_64_unknown_linux_gnu
+coverage:smoke --nocache_test_results

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,50 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+name: Example Smoke Tests
+permissions:
+  contents: read
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  merge_group:
+    types: [checks_requested]
+  push:
+    branches:
+      - main
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.2
+
+      - name: Build examples
+        run: bazel build --lockfile_mode=error --config=smoke //examples/basic/...
+
+      - name: Run example tests
+        run: bazel test --lockfile_mode=error --config=smoke //examples/basic/...
+
+      - name: Run example coverage
+        run: bazel coverage --lockfile_mode=error --config=smoke //examples/basic:basic_test
+
+      - name: Verify coverage data
+        run: |
+          set -euo pipefail
+          dat="bazel-testlogs/examples/basic/basic_test/coverage.dat"
+          test -s "${dat}" || { echo "ERROR: ${dat} missing or empty"; exit 1; }
+          grep -q "^SF:.*examples/basic/src/lib.rs" "${dat}" \
+            || { echo "ERROR: lib.rs not in coverage data"; cat "${dat}"; exit 1; }
+          grep -Eq "^DA:[0-9]+,[1-9]" "${dat}" \
+            || { echo "ERROR: no executed lines recorded"; cat "${dat}"; exit 1; }
+          echo "Coverage smoke OK:"
+          grep -E "^(SF|LF|LH):" "${dat}"

--- a/examples/basic/BUILD.bazel
+++ b/examples/basic/BUILD.bazel
@@ -1,0 +1,37 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+# Minimal Rust targets used to smoke-test the Ferrocene toolchains.
+# Built/tested in CI via: bazel {build,test,coverage} --config=smoke //examples/basic/...
+# See .github/workflows/examples.yml.
+
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
+
+rust_library(
+    name = "basic",
+    srcs = ["src/lib.rs"],
+    edition = "2021",
+)
+
+rust_test(
+    name = "basic_test",
+    crate = ":basic",
+    edition = "2021",
+)
+
+rust_binary(
+    name = "hello",
+    srcs = ["src/main.rs"],
+    edition = "2021",
+    deps = [":basic"],
+)

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,0 +1,17 @@
+# Basic example
+
+Minimal Rust targets demonstrating Ferrocene toolchain usage and serving as
+CI smoke tests (`.github/workflows/examples.yml`):
+
+```bash
+bazel build    --config=smoke //examples/basic/...
+bazel test     --config=smoke //examples/basic/...
+bazel coverage --config=smoke //examples/basic:basic_test
+```
+
+The `smoke` config (see `.bazelrc`) registers the Ferrocene toolchain via
+`--extra_toolchains`, exactly the way downstream repositories consume it.
+The coverage run additionally smoke-tests the LLVM coverage wiring: the
+toolchain's `llvm_cov`/`llvm_profdata` (from the coverage-tools archive)
+make `rules_rust` instrument the test, and CI asserts that the resulting
+LCOV data contains executed lines of `src/lib.rs`.

--- a/examples/basic/src/lib.rs
+++ b/examples/basic/src/lib.rs
@@ -1,0 +1,40 @@
+// *******************************************************************************
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// <https://www.apache.org/licenses/LICENSE-2.0>
+//
+// SPDX-License-Identifier: Apache-2.0
+// *******************************************************************************
+
+//! Tiny example crate used to smoke-test the Ferrocene toolchains.
+//!
+//! `classify` deliberately contains multiple branches so that the coverage
+//! smoke test produces per-branch data, not just straight-line execution.
+
+/// Classifies an integer as `"negative"`, `"zero"` or `"positive"`.
+pub fn classify(n: i32) -> &'static str {
+    if n < 0 {
+        "negative"
+    } else if n == 0 {
+        "zero"
+    } else {
+        "positive"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::classify;
+
+    #[test]
+    fn classifies_all_branches() {
+        assert_eq!(classify(-5), "negative");
+        assert_eq!(classify(0), "zero");
+        assert_eq!(classify(42), "positive");
+    }
+}

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -1,0 +1,22 @@
+// *******************************************************************************
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// <https://www.apache.org/licenses/LICENSE-2.0>
+//
+// SPDX-License-Identifier: Apache-2.0
+// *******************************************************************************
+
+//! Minimal binary exercising the example library.
+
+use basic::classify;
+
+fn main() {
+    for n in [-1, 0, 1] {
+        println!("{n} is {}", classify(n));
+    }
+}


### PR DESCRIPTION
Adds a minimal example crate (library with a branchy function, unit test, binary) that demonstrates toolchain usage and smoke-tests the toolchains on every PR:

- bazel build/test --config=smoke //examples/basic/... exercises the Ferrocene toolchain end to end, consumed via --extra_toolchains the same way downstream repositories do
- bazel coverage additionally smoke-tests the LLVM coverage wiring (llvm_cov/llvm_profdata from the coverage-tools archive): CI asserts the produced LCOV contains executed lines of src/lib.rs, so regressions like a broken coverage-tools archive or missing toolchain attributes are caught before release

Fixes #21